### PR TITLE
feat: variable MaxUnavailbale filebeat's updateStrategy

### DIFF
--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -16,14 +16,12 @@ spec:
     matchLabels:
       app: "{{ template "filebeat.fullname" . }}"
       release: {{ .Release.Name | quote }}
-  {{- if .Values.updateStrategy }}
   updateStrategy:
     {{- if eq .Values.updateStrategy "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
+      maxUnavailable: {{ .Values.maxUnavailable }}
     {{- end }}
     type: {{ .Values.updateStrategy }}
-  {{- end }}
   template:
     metadata:
       annotations:

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
       maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
     {{- end }}
     type: {{ .Values.updateStrategy }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/filebeat/templates/daemonset.yaml
+++ b/filebeat/templates/daemonset.yaml
@@ -16,7 +16,12 @@ spec:
     matchLabels:
       app: "{{ template "filebeat.fullname" . }}"
       release: {{ .Release.Name | quote }}
+  {{- if .Values.updateStrategy }}
   updateStrategy:
+    {{- if eq .Values.updateStrategy "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.maxUnavailable | default 1 }}
+    {{- end }}
     type: {{ .Values.updateStrategy }}
   template:
     metadata:

--- a/filebeat/values.yaml
+++ b/filebeat/values.yaml
@@ -135,6 +135,8 @@ affinity: {}
 priorityClassName: ""
 
 updateStrategy: RollingUpdate
+# Only used when updateStrategy is set to "RollingUpdate"
+MaxUnavalaible: 1
 
 # Override various naming aspects of this chart
 # Only edit these if you know what you're doing


### PR DESCRIPTION
## Problem

Unable to set a custom value for the `MaxUnavalaible` for the `rollingUpdate` filebeat's update strategy.
This option should be available especially for filebeat, because there is no need to have a MaxUnavailable set to 1 when there's one filebeat pod per node.

## What I've done in my PR

Add an {{- if }} statement to the updateStrategy regarding the MaxUnavaillable variable. If the variable is not set, the default value is set to 1 (current value set right now).

Chart version

filebeat 7.9.1

Tools versions

Helm version
Client: {Version:"v3.3.0", GitCommit:"8a4aeec08d67a7b84472007529e8097ec3742105", GitTreeState:"dirty", GoVersion:"go1.14.6"}

kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.8", GitCommit:"9f2892aab98fe339f3bd70e3c470144299398ace", GitTreeState:"clean", BuildDate:"2020-08-13T16:12:48Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"darwin/amd64"}